### PR TITLE
Fix routing, transition groups

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,17 +3,7 @@
   "env": {
     "development": {
       "plugins": [
-        ["transform-react-display-name"],
-        ["react-transform", {
-          "transforms": [{
-            "transform": "react-transform-hmr",
-            "imports": ["react"],
-            "locals": ["module"]
-          }, {
-            "transform": "react-transform-catch-errors",
-            "imports": ["react", "redbox-react"]
-          }]
-        }]
+        ["transform-react-display-name"]
       ]
     },
     "production": {

--- a/client/components/app.js
+++ b/client/components/app.js
@@ -1,4 +1,5 @@
 import { bindActionCreators } from 'redux'
+import { withRouter } from 'react-router';
 import { connect } from 'react-redux'
 import * as actionCreators from '../actions/action-creators'
 import Main from './main'
@@ -18,4 +19,4 @@ const mapDispatchToProps = dispatch => {
 // take state, then action creators, into connect via props
 const App = connect(mapStateToProps, mapDispatchToProps)(Main)
 
-export default App;
+export default withRouter(App);

--- a/client/components/main.js
+++ b/client/components/main.js
@@ -1,15 +1,29 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Photogrid from './photogrid';
+import Single from './single';
+import { Switch, Route } from 'react-router-dom';
 
-const Main = (props) => {
+export default class Main extends React.Component {
+    render() {
+        const props = this.props;
+
         return (
             <div>
-            <Link to="/"><h1>Rodriguezstagram</h1></Link>
-            {
-                props.children &&
-                React.cloneElement(props.children, props)
-            }
+                <Link to="/"><h1>Rodriguezstagram</h1></Link>
+
+                <Switch>
+                    <Route path='/view/:postId' render={(routerProps) => {
+                        return <Single {...props} {...routerProps} />
+                    }}></Route>
+                    <Route path='/photogrid' render={(routerProps) => {
+                        return <Photogrid {...props} {...routerProps} />
+                    }}></Route>
+                    <Route exact path='/' render={(routerProps) => {
+                        return <Photogrid {...props} {...routerProps} />
+                    }}></Route>
+                </Switch>
             </div>
         )
+    }
 }
-export default Main

--- a/client/components/photo.js
+++ b/client/components/photo.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+
+ class Photo extends Component {
+     render() {
+         const {post, i, comments} = this.props;
+
+         return (
+             <figure className="grid-figure">
+                <div className="grid-photo-wrap">
+                    <Link to={`/view/${post.code}`}>
+                        <img src={post.display_src} alt={post.caption} className="grid-photo"/>
+                    </Link>
+
+                    <TransitionGroup className="likes-heart" component={null}>
+                    <CSSTransition key={post.likes} 
+                        classNames="likes-heart"
+                        timeout={500}>
+                        <span key={post.likes}></span>    
+                    </CSSTransition> 
+                    </TransitionGroup>
+                </div>
+                <figcaption>
+                    <p>{post.caption}</p>
+                    <div className="control-buttons">
+                        <button className="likes">&hearts; {post.likes}</button>
+                        <Link className="button" to={`/view/${post.code}`}>
+                        <span className="comment-count">
+                            <span className="speech-bubble"></span>
+                                {comments[post.code] ? comments[post.code].length : 0}
+                            </span>
+                        </Link>
+                    </div>
+                </figcaption>
+             </figure>
+         )
+     }
+ }
+
+ export default Photo;

--- a/client/components/photogrid.js
+++ b/client/components/photogrid.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import Photo from './photo';
 
-const Photogrid = () => {
+const Photogrid = (props) => {
+    console.log(props.posts);
+
     return (
         <div className="photo-grid">
-        Photo grid here
+        {props.posts.map((post, index) => <Photo {...props} key={index} index={index} post={post}/>)}        
         </div>
     )
 }

--- a/client/reducers/comments.js
+++ b/client/reducers/comments.js
@@ -3,7 +3,6 @@
 // 2 - a copy of the current state
 
 const comments = (state = [], action) => {
-    console.log(state, action);
     return state;
 }
 

--- a/client/reducers/posts.js
+++ b/client/reducers/posts.js
@@ -3,7 +3,6 @@
 // 2 - a copy of the current state
 
 const posts = (state = [], action) => {
-    console.log(state, action);
     return state;
 }
 

--- a/client/reduxstagram.js
+++ b/client/reduxstagram.js
@@ -2,21 +2,14 @@ import React from 'react';
 import {render} from 'react-dom';
 import App from './components/app';
 import css from './styles/style.styl';
-import { BrowserRouter, Switch, Route, Router } from 'react-router-dom';
-import Single from './components/single';
-import Photogrid from './components/photogrid';
+import { BrowserRouter } from 'react-router-dom';
 import {Provider} from 'react-redux'
 import store from './store';
 
 render( 
     <Provider store = {store}>
         <BrowserRouter>
-            <App>
-                <Switch>
-                    <Route path='/view/:postId' component={Single}></Route>
-                    <Route path='/' component={Photogrid}></Route>
-                </Switch>
-            </App>
+            <App />
         </BrowserRouter>
     </Provider>,
 

--- a/client/store.js
+++ b/client/store.js
@@ -5,7 +5,7 @@ import rootReducer from './reducers'
 
 // default data
 import posts from './data/posts'
-import comments from './data/posts'
+import comments from './data/comments'
 
 // create object for default data
 const defaultState = {
@@ -13,7 +13,8 @@ const defaultState = {
     comments
 }
 
-const store = createStore(rootReducer, defaultState);
+const store = createStore(rootReducer, defaultState, 
+window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
 
 // export const history = syncHistoryWithStore(BrowserHistory, store);
 export default store;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,11 +1692,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000904.tgz",
       "integrity": "sha512-M4sXvogCoY5Fp6fuXIaQG/MIexlEFQ3Lgwban+KlqiQUbUIkSmjAB8ZJIP79aj2cdqz2F1Lb+Z+5GwHvCrbLtg=="
     },
-    "chain-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -5366,14 +5361,6 @@
         "scheduler": "^0.10.0"
       }
     },
-    "react-addons-css-transition-group": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz",
-      "integrity": "sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=",
-      "requires": {
-        "react-transition-group": "^1.2.0"
-      }
-    },
     "react-addons-test-utils": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
@@ -5524,15 +5511,14 @@
       }
     },
     "react-transition-group": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
+      "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
       "requires": {
-        "chain-function": "^1.0.0",
-        "dom-helpers": "^3.2.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.6",
-        "warning": "^3.0.0"
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/wesbos/Learn-Redux",
   "dependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/helper-module-imports": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.1",
@@ -33,7 +34,6 @@
     "express": "^4.13.4",
     "raven-js": "^3.27.0",
     "react": "^16.6.0",
-    "react-addons-css-transition-group": "^15.0.2",
     "react-dom": "^16.6.0",
     "react-redux": "^5.1.0",
     "react-router": "^4.3.1",
@@ -41,6 +41,7 @@
     "react-router-redux": "^4.0.4",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
+    "react-transition-group": "^2.5.0",
     "redbox-react": "^1.2.3",
     "redux": "^4.0.1",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
Significant changes made to the app.

Because React Router 4 does not use child routes anymore (previously you would for something like IndexRoute), we have to make some modifications to the reduxstagram entry file and the Main.js file.

Previously, without this change, I had some conditional statement as a temporary hack to prevent the title H1 tag from being duplicated, but what was really happening was the Switch component from react-router was being duplicated, and not correctly passing props down to the photogrid and single components. 

By modifying the entry file to wrap the Router around the App component, then modifying Main to pull in the Photogrid and Single components, we can correctly pass down props. In app.js, you must wrap the exported component in withRouter, so that routing works correctly (try it without - you'll see the Single component route does not work, you click it but goes nowhere).

I had to remove a transform from babelrc that was breaking when trying to compile class components. Haven't figured this out yet. 

Also updated react-transition-group - their API is completely different now (v2).